### PR TITLE
Make storage interface asynchronous

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["flow", "react", "es2015"],
-  "plugins": ["transform-object-rest-spread", "transform-class-properties"]
+  "plugins": ["transform-object-rest-spread", "transform-class-properties", "transform-async-to-generator"]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",
     "babel-loader": "^7.0.0",
+    "babel-plugin-transform-async-to-generator": "^6.24.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",

--- a/src/api.js
+++ b/src/api.js
@@ -4,7 +4,7 @@ import { authnFetch } from './authn-fetch'
 import { currentUrlNoParams } from './browser-util'
 import type { session } from './session'
 import { getSession, saveSession, clearSession } from './session'
-import type { Storage } from './storage'
+import type { AsyncStorage } from './storage'
 import { defaultStorage } from './storage'
 import * as WebIdTls from './webid-tls'
 import * as WebIdOidc from './webid-oidc'
@@ -16,7 +16,7 @@ export type authResponse =
 
 export type loginOptions = {
   redirectUri: ?string,
-  storage: Storage
+  storage: AsyncStorage
 }
 
 const defaultLoginOptions = (): loginOptions => {
@@ -30,7 +30,7 @@ const defaultLoginOptions = (): loginOptions => {
 export const fetch = (url: RequestInfo, options?: Object): Promise<Response> =>
   authnFetch(defaultStorage())(url, options)
 
-const responseFromFirstSession = async (storage: Storage, authFns: Array<() => Promise<?session>>): Promise<authResponse> => {
+const responseFromFirstSession = async (storage: AsyncStorage, authFns: Array<() => Promise<?session>>): Promise<authResponse> => {
   if (authFns.length === 0) {
     return { session: null, fetch: authnFetch(storage) }
   }
@@ -53,7 +53,7 @@ export const login = (idp: string, options: loginOptions): Promise<authResponse>
   ])
 }
 
-export const currentSession = async (storage: Storage = defaultStorage()): Promise<authResponse> => {
+export const currentSession = async (storage: AsyncStorage = defaultStorage()): Promise<authResponse> => {
   const session = await getSession(storage)
   if (session) {
     return { session, fetch: authnFetch(storage) }
@@ -63,7 +63,7 @@ export const currentSession = async (storage: Storage = defaultStorage()): Promi
   ])
 }
 
-export const logout = (storage: Storage = defaultStorage()): Promise<void> =>
+export const logout = (storage: AsyncStorage = defaultStorage()): Promise<void> =>
   Promise.resolve(getSession(storage))
     .then(session => session && session.idToken && session.accessToken
       ? WebIdOidc.logout(storage)

--- a/src/api.js
+++ b/src/api.js
@@ -30,14 +30,14 @@ const defaultLoginOptions = (): loginOptions => {
 export const fetch = (url: RequestInfo, options?: Object): Promise<Response> =>
   authnFetch(defaultStorage())(url, options)
 
-const responseFromFirstSession = (storage: Storage, authFns: Array<() => Promise<?session>>): Promise<authResponse> => {
+const responseFromFirstSession = async (storage: Storage, authFns: Array<() => Promise<?session>>): Promise<authResponse> => {
   if (authFns.length === 0) {
-    return Promise.resolve({ session: null, fetch: authnFetch(storage) })
+    return { session: null, fetch: authnFetch(storage) }
   }
   return authFns[0]()
-    .then(session =>
+    .then(async session =>
       session
-        ? { session: saveSession(storage)(session), fetch: authnFetch(storage) }
+        ? { session: await saveSession(storage)(session), fetch: authnFetch(storage) }
         : responseFromFirstSession(storage, authFns.slice(1)))
     .catch(err => {
       console.error(err)
@@ -53,10 +53,10 @@ export const login = (idp: string, options: loginOptions): Promise<authResponse>
   ])
 }
 
-export const currentSession = (storage: Storage = defaultStorage()): Promise<authResponse> => {
-  const session = getSession(storage)
+export const currentSession = async (storage: Storage = defaultStorage()): Promise<authResponse> => {
+  const session = await getSession(storage)
   if (session) {
-    return Promise.resolve({ session, fetch: authnFetch(storage) })
+    return { session, fetch: authnFetch(storage) }
   }
   return responseFromFirstSession(storage, [
     WebIdOidc.currentSession.bind(null, storage)

--- a/src/api.spec.js
+++ b/src/api.spec.js
@@ -9,7 +9,6 @@ import URLSearchParams from 'url-search-params'
 import { currentSession, fetch, login, logout } from './api'
 import { saveHost } from './hosts'
 import { getSession, saveSession } from './session'
-import { memStorage } from './storage'
 
 /*
  * OIDC test data:
@@ -70,7 +69,18 @@ beforeEach(() => {
     return url
   }
   window.URLSearchParams = URLSearchParams
-  window.localStorage = memStorage()
+  const store = {}
+  window.localStorage = {
+    length: 0,
+    key: (i) => Object.keys(store)[i],
+    getItem: (key) => key in store ? store[key] : null,
+    setItem: (key, val) => {
+      if (!(key in store)) {
+        window.localStorage.length++
+      }
+      store[key] = val
+    }
+  }
 })
 
 afterEach(() => {

--- a/src/api.spec.js
+++ b/src/api.spec.js
@@ -98,9 +98,9 @@ describe('login', () => {
       .reply(404)
 
     return login('https://localhost')
-      .then(({ session }) => {
+      .then(async ({ session }) => {
         expect(session).toBeNull()
-        expect(getSession(window.localStorage)).toBeNull()
+        expect(await getSession(window.localStorage)).toBeNull()
       })
   })
 
@@ -112,9 +112,9 @@ describe('login', () => {
         .reply(200, '', { user: webId })
 
       return login('https://localhost')
-        .then(({ session }) => {
+        .then(async ({ session }) => {
           expect(session.webId).toBe(webId)
-          expect(getSession(window.localStorage)).toEqual(session)
+          expect(await getSession(window.localStorage)).toEqual(session)
         })
     })
   })
@@ -213,17 +213,17 @@ describe('currentSession', () => {
     })
 
     return currentSession()
-      .then(({ session }) => {
+      .then(async ({ session }) => {
         expect(session.webId).toBe('https://person.me/#me')
-        expect(getSession(window.localStorage)).toEqual(session)
+        expect(await getSession(window.localStorage)).toEqual(session)
       })
   })
 
   it('resolves to a `null` session when there is no stored session or OIDC response', () => {
     return currentSession()
-      .then(({ session }) => {
+      .then(async ({ session }) => {
         expect(session).toBeNull()
-        expect(getSession(window.localStorage)).toBeNull()
+        expect(await getSession(window.localStorage)).toBeNull()
       })
   })
 
@@ -278,11 +278,11 @@ describe('currentSession', () => {
             `state=${state}`
         })
         .then(currentSession)
-        .then(({ session }) => {
+        .then(async ({ session }) => {
           expect(session.webId).toBe('https://person.me/#me')
           expect(session.accessToken).toBe(expectedAccessToken)
           expect(session.idToken).toBe(expectedIdToken)
-          expect(getSession(window.localStorage)).toEqual(session)
+          expect(await getSession(window.localStorage)).toEqual(session)
           expect(window.location.hash).toBe('')
         })
     })
@@ -299,8 +299,8 @@ describe('logout', () => {
       })
 
       return logout()
-        .then(() => {
-          expect(getSession(window.localStorage)).toBeNull()
+        .then(async () => {
+          expect(await getSession(window.localStorage)).toBeNull()
         })
     })
   })
@@ -359,16 +359,16 @@ describe('logout', () => {
             `state=${state}`
         })
         .then(currentSession)
-        .then(({ session }) => {
+        .then(async ({ session }) => {
           expect(session.webId).toBe('https://person.me/#me')
           expect(session.accessToken).toBe(expectedAccessToken)
           expect(session.idToken).toBe(expectedIdToken)
           expect(window.location.hash).toBe('')
-          expect(getSession(window.localStorage)).toEqual(session)
+          expect(await getSession(window.localStorage)).toEqual(session)
         })
         .then(() => logout())
-        .then(() => {
-          expect(getSession(window.localStorage)).toBeNull()
+        .then(async () => {
+          expect(await getSession(window.localStorage)).toBeNull()
         })
     })
   })

--- a/src/api.spec.js
+++ b/src/api.spec.js
@@ -103,37 +103,33 @@ describe('login', () => {
     nock.enableNetConnect()
   })
 
-  it('returns an anonymous auth response when no recognized auth scheme is present', () => {
+  it('returns an anonymous auth response when no recognized auth scheme is present', async () => {
     nock('https://localhost')
       .head('/')
       .reply(200)
       .get('/.well-known/openid-configuration')
       .reply(404)
 
-    return login('https://localhost')
-      .then(async ({ session }) => {
-        expect(session).toBeNull()
-        expect(await getSession(storage)).toBeNull()
-      })
+    const { session } = await login('https://localhost')
+    expect(session).toBeNull()
+    expect(await getSession(storage)).toBeNull()
   })
 
   describe('WebID-TLS', () => {
-    it('can log in with WebID-TLS', () => {
+    it('can log in with WebID-TLS', async () => {
       const webId = 'https://localhost/profile#me'
       nock('https://localhost/')
         .head('/')
         .reply(200, '', { user: webId })
 
-      return login('https://localhost')
-        .then(async ({ session }) => {
-          expect(session.webId).toBe(webId)
-          expect(await getSession(storage)).toEqual(session)
-        })
+      const { session } = await login('https://localhost')
+      expect(session.webId).toBe(webId)
+      expect(await getSession(storage)).toEqual(session)
     })
   })
 
   describe('WebID-OIDC', () => {
-    it('can log in with WebID-OIDC', () => {
+    it('can log in with WebID-OIDC', async () => {
       nock('https://localhost/')
         // try to log in with WebID-TLS
         .head('/')
@@ -146,19 +142,17 @@ describe('login', () => {
         .post('/register')
         .reply(200, oidcRegistration)
 
-      return login('https://localhost')
-        .then(() => {
-          const location = new window.URL(window.location.href)
-          expect(location.origin).toEqual('https://localhost')
-          expect(location.pathname).toEqual('/authorize')
-          expect(location.searchParams.get('redirect_uri')).toEqual('https://app.biz/')
-          expect(location.searchParams.get('response_type')).toEqual('id_token token')
-          expect(location.searchParams.get('scope')).toEqual('openid')
-          expect(location.searchParams.get('client_id')).toEqual('the-client-id')
-        })
+      await login('https://localhost')
+      const location = new window.URL(window.location.href)
+      expect(location.origin).toEqual('https://localhost')
+      expect(location.pathname).toEqual('/authorize')
+      expect(location.searchParams.get('redirect_uri')).toEqual('https://app.biz/')
+      expect(location.searchParams.get('response_type')).toEqual('id_token token')
+      expect(location.searchParams.get('scope')).toEqual('openid')
+      expect(location.searchParams.get('client_id')).toEqual('the-client-id')
     })
 
-    it('uses the provided redirect uri', () => {
+    it('uses the provided redirect uri', async () => {
       nock('https://localhost')
         // try to log in with WebID-TLS
         .head('/')
@@ -171,19 +165,17 @@ describe('login', () => {
         .post('/register')
         .reply(200, oidcRegistration)
 
-      return login('https://localhost', { redirectUri: 'https://app.biz/welcome/' })
-        .then(() => {
-          const location = new window.URL(window.location.href)
-          expect(location.origin).toEqual('https://localhost')
-          expect(location.pathname).toEqual('/authorize')
-          expect(location.searchParams.get('redirect_uri')).toEqual('https://app.biz/welcome/')
-          expect(location.searchParams.get('response_type')).toEqual('id_token token')
-          expect(location.searchParams.get('scope')).toEqual('openid')
-          expect(location.searchParams.get('client_id')).toEqual('the-client-id')
-        })
+      await login('https://localhost', { redirectUri: 'https://app.biz/welcome/' })
+      const location = new window.URL(window.location.href)
+      expect(location.origin).toEqual('https://localhost')
+      expect(location.pathname).toEqual('/authorize')
+      expect(location.searchParams.get('redirect_uri')).toEqual('https://app.biz/welcome/')
+      expect(location.searchParams.get('response_type')).toEqual('id_token token')
+      expect(location.searchParams.get('scope')).toEqual('openid')
+      expect(location.searchParams.get('client_id')).toEqual('the-client-id')
     })
 
-    it('strips the hash fragment from the current URL when proiding the default redirect URL', () => {
+    it('strips the hash fragment from the current URL when proiding the default redirect URL', async () => {
       nock('https://localhost/')
         // try to log in with WebID-TLS
         .head('/')
@@ -198,16 +190,14 @@ describe('login', () => {
 
       window.location.href += '#foo-bar'
 
-      return login('https://localhost')
-        .then(() => {
-          const location = new window.URL(window.location.href)
-          expect(location.origin).toEqual('https://localhost')
-          expect(location.pathname).toEqual('/authorize')
-          expect(location.searchParams.get('redirect_uri')).toEqual('https://app.biz/')
-          expect(location.searchParams.get('response_type')).toEqual('id_token token')
-          expect(location.searchParams.get('scope')).toEqual('openid')
-          expect(location.searchParams.get('client_id')).toEqual('the-client-id')
-        })
+      await login('https://localhost')
+      const location = new window.URL(window.location.href)
+      expect(location.origin).toEqual('https://localhost')
+      expect(location.pathname).toEqual('/authorize')
+      expect(location.searchParams.get('redirect_uri')).toEqual('https://app.biz/')
+      expect(location.searchParams.get('response_type')).toEqual('id_token token')
+      expect(location.searchParams.get('scope')).toEqual('openid')
+      expect(location.searchParams.get('client_id')).toEqual('the-client-id')
     })
 
     // TODO: this is broken due to https://github.com/anvilresearch/oidc-rp/issues/26
@@ -225,23 +215,19 @@ describe('currentSession', () => {
       idToken: 'abc.def.ghi'
     })
 
-    return currentSession()
-      .then(async ({ session }) => {
-        expect(session.webId).toBe('https://person.me/#me')
-        expect(await getSession(storage)).toEqual(session)
-      })
+    const { session } = await currentSession()
+    expect(session.webId).toBe('https://person.me/#me')
+    expect(await getSession(storage)).toEqual(session)
   })
 
-  it('resolves to a `null` session when there is no stored session or OIDC response', () => {
-    return currentSession()
-      .then(async ({ session }) => {
-        expect(session).toBeNull()
-        expect(await getSession(storage)).toBeNull()
-      })
+  it('resolves to a `null` session when there is no stored session or OIDC response', async () => {
+    const { session } = await currentSession()
+    expect(session).toBeNull()
+    expect(await getSession(storage)).toBeNull()
   })
 
   describe('WebID-OIDC', () => {
-    it('can find the current session from the URL auth response', () => {
+    it('can find the current session from the URL auth response', async () => {
       // To test currentSession with WebID-OIDC it's easist to set up the OIDC RP
       // client by logging in, generating the IDP's response, and redirecting
       // back to the app.
@@ -262,42 +248,39 @@ describe('currentSession', () => {
 
       let expectedIdToken, expectedAccessToken
 
-      return login('https://localhost')
-        .then(() => {
-          // generate the auth response
-          const location = new window.URL(window.location.href)
-          const state = location.searchParams.get('state')
-          const redirectUri = location.searchParams.get('redirect_uri')
-          const nonce = location.searchParams.get('nonce')
-          const accessToken = 'example_access_token'
-          const { alg } = jwks.keys[0]
-          const idToken = jwt.sign(
-            {
-              iss: oidcConfiguration.issuer,
-              aud: oidcRegistration.client_id,
-              exp: Math.floor(Date.now() / 1000) + (60 * 60), // one hour
-              sub: 'https://person.me/#me',
-              nonce
-            },
-            pem,
-            { algorithm: alg }
-          )
-          expectedIdToken = idToken
-          expectedAccessToken = accessToken
-          window.location.href = `${redirectUri}#` +
-            `access_token=${accessToken}&` +
-            `token_type=Bearer&` +
-            `id_token=${idToken}&` +
-            `state=${state}`
-        })
-        .then(currentSession)
-        .then(async ({ session }) => {
-          expect(session.webId).toBe('https://person.me/#me')
-          expect(session.accessToken).toBe(expectedAccessToken)
-          expect(session.idToken).toBe(expectedIdToken)
-          expect(await getSession(storage)).toEqual(session)
-          expect(window.location.hash).toBe('')
-        })
+      await login('https://localhost')
+      // generate the auth response
+      const location = new window.URL(window.location.href)
+      const state = location.searchParams.get('state')
+      const redirectUri = location.searchParams.get('redirect_uri')
+      const nonce = location.searchParams.get('nonce')
+      const accessToken = 'example_access_token'
+      const { alg } = jwks.keys[0]
+      const idToken = jwt.sign(
+        {
+          iss: oidcConfiguration.issuer,
+          aud: oidcRegistration.client_id,
+          exp: Math.floor(Date.now() / 1000) + (60 * 60), // one hour
+          sub: 'https://person.me/#me',
+          nonce
+        },
+        pem,
+        { algorithm: alg }
+      )
+      expectedIdToken = idToken
+      expectedAccessToken = accessToken
+      window.location.href = `${redirectUri}#` +
+        `access_token=${accessToken}&` +
+        `token_type=Bearer&` +
+        `id_token=${idToken}&` +
+        `state=${state}`
+
+      const { session } = await currentSession()
+      expect(session.webId).toBe('https://person.me/#me')
+      expect(session.accessToken).toBe(expectedAccessToken)
+      expect(session.idToken).toBe(expectedIdToken)
+      expect(await getSession(storage)).toEqual(session)
+      expect(window.location.hash).toBe('')
     })
   })
 })
@@ -311,15 +294,13 @@ describe('logout', () => {
         webId: 'https://person.me/#me'
       })
 
-      return logout()
-        .then(async () => {
-          expect(await getSession(storage)).toBeNull()
-        })
+      await logout()
+      expect(await getSession(storage)).toBeNull()
     })
   })
 
   describe('WebID-OIDC', () => {
-    it('hits the end_session_endpoint and clears the current session from the store', () => {
+    it('hits the end_session_endpoint and clears the current session from the store', async () => {
       // To test currentSession with WebID-OIDC it's easist to set up the OIDC RP
       // client by logging in, generating the IDP's response, and redirecting
       // back to the app.
@@ -343,46 +324,42 @@ describe('logout', () => {
 
       let expectedIdToken, expectedAccessToken
 
-      return login('https://localhost')
-        .then(() => {
-          // generate the auth response
-          const location = new window.URL(window.location.href)
-          const state = location.searchParams.get('state')
-          const redirectUri = location.searchParams.get('redirect_uri')
-          const nonce = location.searchParams.get('nonce')
-          const accessToken = 'example_access_token'
-          const { alg } = jwks.keys[0]
-          const idToken = jwt.sign(
-            {
-              iss: oidcConfiguration.issuer,
-              aud: oidcRegistration.client_id,
-              exp: Math.floor(Date.now() / 1000) + (60 * 60), // one hour
-              sub: 'https://person.me/#me',
-              nonce
-            },
-            pem,
-            { algorithm: alg }
-          )
-          expectedIdToken = idToken
-          expectedAccessToken = accessToken
-          window.location.href = `${redirectUri}#` +
-            `access_token=${accessToken}&` +
-            `token_type=Bearer&` +
-            `id_token=${idToken}&` +
-            `state=${state}`
-        })
-        .then(currentSession)
-        .then(async ({ session }) => {
-          expect(session.webId).toBe('https://person.me/#me')
-          expect(session.accessToken).toBe(expectedAccessToken)
-          expect(session.idToken).toBe(expectedIdToken)
-          expect(window.location.hash).toBe('')
-          expect(await getSession(storage)).toEqual(session)
-        })
-        .then(() => logout())
-        .then(async () => {
-          expect(await getSession(storage)).toBeNull()
-        })
+      await login('https://localhost')
+      // generate the auth response
+      const location = new window.URL(window.location.href)
+      const state = location.searchParams.get('state')
+      const redirectUri = location.searchParams.get('redirect_uri')
+      const nonce = location.searchParams.get('nonce')
+      const accessToken = 'example_access_token'
+      const { alg } = jwks.keys[0]
+      const idToken = jwt.sign(
+        {
+          iss: oidcConfiguration.issuer,
+          aud: oidcRegistration.client_id,
+          exp: Math.floor(Date.now() / 1000) + (60 * 60), // one hour
+          sub: 'https://person.me/#me',
+          nonce
+        },
+        pem,
+        { algorithm: alg }
+      )
+      expectedIdToken = idToken
+      expectedAccessToken = accessToken
+      window.location.href = `${redirectUri}#` +
+        `access_token=${accessToken}&` +
+        `token_type=Bearer&` +
+        `id_token=${idToken}&` +
+        `state=${state}`
+
+      const { session } = await currentSession()
+      expect(session.webId).toBe('https://person.me/#me')
+      expect(session.accessToken).toBe(expectedAccessToken)
+      expect(session.idToken).toBe(expectedIdToken)
+      expect(window.location.hash).toBe('')
+      expect(await getSession(storage)).toEqual(session)
+
+      await logout()
+      expect(await getSession(storage)).toBeNull()
     })
   })
 })
@@ -404,10 +381,8 @@ describe('fetch', () => {
       .matchHeader('authorization', 'Bearer abc.def.ghi')
       .reply(200)
 
-    return fetch('https://third-party.com/protected-resource')
-      .then(resp => {
-        expect(resp.status).toBe(200)
-      })
+    const resp = await fetch('https://third-party.com/protected-resource')
+    expect(resp.status).toBe(200)
   })
 
   it('merges request headers with the authorization header', async () => {
@@ -427,10 +402,8 @@ describe('fetch', () => {
       .matchHeader('authorization', 'Bearer abc.def.ghi')
       .reply(200)
 
-    return fetch('https://third-party.com/private-resource', { headers: { accept: 'text/plain' } })
-      .then(resp => {
-        expect(resp.status).toBe(200)
-      })
+    const resp = await fetch('https://third-party.com/private-resource', { headers: { accept: 'text/plain' } })
+    expect(resp.status).toBe(200)
   })
 
   it('does not resend with credentials if the www-authenticate header is missing', async () => {
@@ -446,10 +419,8 @@ describe('fetch', () => {
       .get('/protected-resource')
       .reply(401)
 
-    return fetch('https://third-party.com/protected-resource')
-      .then(resp => {
-        expect(resp.status).toBe(401)
-      })
+    const resp = await fetch('https://third-party.com/protected-resource')
+    expect(resp.status).toBe(401)
   })
 
   it('does not resend with credentials if the www-authenticate header suggests an unknown scheme', async () => {
@@ -465,47 +436,37 @@ describe('fetch', () => {
       .get('/protected-resource')
       .reply(401, '', { 'www-authenticate': 'Basic token' })
 
-    return fetch('https://third-party.com/protected-resource')
-      .then(resp => {
-        expect(resp.status).toBe(401)
-      })
+    const resp = await fetch('https://third-party.com/protected-resource')
+    expect(resp.status).toBe(401)
   })
 
-  it('does not resend with credentials if there is no session', () => {
+  it('does not resend with credentials if there is no session', async () => {
     nock('https://third-party.com')
       .get('/protected-resource')
       .reply(401, '', { 'www-authenticate': 'Bearer scope="openid webid"' })
 
-    return fetch('https://third-party.com/protected-resource')
-      .then(resp => {
-        expect(resp.status).toBe(401)
-      })
+    const resp = await fetch('https://third-party.com/protected-resource')
+    expect(resp.status).toBe(401)
   })
 
-  it('does not resend with credentials if the requested resource is public', () => {
+  it('does not resend with credentials if the requested resource is public', async () => {
     nock('https://third-party.com')
       .get('/public-resource')
       .reply(200, 'public content', { 'content-type': 'text/plain' })
 
-    return fetch('https://third-party.com/public-resource')
-      .then(resp => {
-        expect(resp.status).toBe(200)
-        return resp.text()
-      })
-      .then(body => {
-        expect(body).toEqual('public content')
-      })
+    const resp = await fetch('https://third-party.com/public-resource')
+    expect(resp.status).toBe(200)
+    const body = await resp.text()
+    expect(body).toEqual('public content')
   })
 
-  it('does not resend with credentials if the requested resources uses plain OIDC', () => {
+  it('does not resend with credentials if the requested resources uses plain OIDC', async () => {
     nock('https://third-party.com')
       .get('/protected-resource')
       .reply(401, '', { 'www-authenticate': 'Bearer scope="openid"' })
 
-    return fetch('https://third-party.com/protected-resource')
-      .then(resp => {
-        expect(resp.status).toBe(401)
-      })
+    const resp = await fetch('https://third-party.com/protected-resource')
+    expect(resp.status).toBe(401)
   })
 
   describe('familiar domains with WebID-OIDC', () => {
@@ -523,10 +484,8 @@ describe('fetch', () => {
         .matchHeader('authorization', 'Bearer abc.def.ghi')
         .reply(200)
 
-      return fetch('https://localhost/resource')
-        .then(resp => {
-          expect(resp.status).toBe(200)
-        })
+      const resp = await fetch('https://localhost/resource')
+      expect(resp.status).toBe(200)
     })
 
     it('just sends one request to domains it has already encountered', async () => {
@@ -548,10 +507,8 @@ describe('fetch', () => {
         .matchHeader('authorization', 'Bearer abc.def.ghi')
         .reply(200)
 
-      return fetch('https://third-party.com/resource')
-        .then(resp => {
-          expect(resp.status).toBe(200)
-        })
+      const resp = await fetch('https://third-party.com/resource')
+      expect(resp.status).toBe(200)
     })
 
     it('does not send credentials to a familiar domain when that domain uses a different auth type', async () => {
@@ -572,10 +529,8 @@ describe('fetch', () => {
         .get('/resource')
         .reply(401)
 
-      return fetch('https://third-party.com/resource')
-        .then(resp => {
-          expect(resp.status).toBe(401)
-        })
+      const resp = await fetch('https://third-party.com/resource')
+      expect(resp.status).toBe(401)
     })
   })
 })

--- a/src/api.spec.js
+++ b/src/api.spec.js
@@ -216,8 +216,8 @@ describe('login', () => {
 })
 
 describe('currentSession', () => {
-  it('can find the current session if stored', () => {
-    saveSession(storage)({
+  it('can find the current session if stored', async () => {
+    await saveSession(storage)({
       authType: 'WebID-OIDC',
       idp: 'https://localhost',
       webId: 'https://person.me/#me',
@@ -304,8 +304,8 @@ describe('currentSession', () => {
 
 describe('logout', () => {
   describe('WebID-TLS', () => {
-    it('just removes the current session from the store', () => {
-      saveSession(storage)({
+    it('just removes the current session from the store', async () => {
+      await saveSession(storage)({
         authType: 'WebID-TLS',
         idp: 'https://localhost',
         webId: 'https://person.me/#me'
@@ -388,8 +388,8 @@ describe('logout', () => {
 })
 
 describe('fetch', () => {
-  it('handles 401s from WebID-OIDC resources by resending with credentials', () => {
-    saveSession(storage)({
+  it('handles 401s from WebID-OIDC resources by resending with credentials', async () => {
+    await saveSession(storage)({
       authType: 'WebID-OIDC',
       idp: 'https://localhost',
       webId: 'https://person.me/#me',
@@ -410,8 +410,8 @@ describe('fetch', () => {
       })
   })
 
-  it('merges request headers with the authorization header', () => {
-    saveSession(storage)({
+  it('merges request headers with the authorization header', async () => {
+    await saveSession(storage)({
       authType: 'WebID-OIDC',
       idp: 'https://localhost',
       webId: 'https://person.me/#me',
@@ -433,8 +433,8 @@ describe('fetch', () => {
       })
   })
 
-  it('does not resend with credentials if the www-authenticate header is missing', () => {
-    saveSession(storage)({
+  it('does not resend with credentials if the www-authenticate header is missing', async () => {
+    await saveSession(storage)({
       authType: 'WebID-OIDC',
       idp: 'https://localhost',
       webId: 'https://person.me/#me',
@@ -452,8 +452,8 @@ describe('fetch', () => {
       })
   })
 
-  it('does not resend with credentials if the www-authenticate header suggests an unknown scheme', () => {
-    saveSession(storage)({
+  it('does not resend with credentials if the www-authenticate header suggests an unknown scheme', async () => {
+    await saveSession(storage)({
       authType: 'WebID-OIDC',
       idp: 'https://localhost',
       webId: 'https://person.me/#me',
@@ -509,8 +509,8 @@ describe('fetch', () => {
   })
 
   describe('familiar domains with WebID-OIDC', () => {
-    it('just sends one request when the RP is also the IDP', () => {
-      saveSession(storage)({
+    it('just sends one request when the RP is also the IDP', async () => {
+      await saveSession(storage)({
         authType: 'WebID-OIDC',
         idp: 'https://localhost',
         webId: 'https://person.me/#me',
@@ -529,8 +529,8 @@ describe('fetch', () => {
         })
     })
 
-    it('just sends one request to domains it has already encountered', () => {
-      saveSession(storage)({
+    it('just sends one request to domains it has already encountered', async () => {
+      await saveSession(storage)({
         authType: 'WebID-OIDC',
         idp: 'https://localhost',
         webId: 'https://person.me/#me',
@@ -554,8 +554,8 @@ describe('fetch', () => {
         })
     })
 
-    it('does not send credentials to a familiar domain when that domain uses a different auth type', () => {
-      saveSession(storage)({
+    it('does not send credentials to a familiar domain when that domain uses a different auth type', async () => {
+      await saveSession(storage)({
         authType: 'WebID-OIDC',
         idp: 'https://localhost',
         webId: 'https://person.me/#me',

--- a/src/authn-fetch.js
+++ b/src/authn-fetch.js
@@ -5,10 +5,10 @@ import 'isomorphic-fetch'
 import { getHost, updateHostFromResponse } from './hosts'
 import type { session } from './session'
 import { getSession } from './session'
-import type { Storage } from './storage'
+import type { AsyncStorage } from './storage'
 import * as WebIdOidc from './webid-oidc'
 
-export const authnFetch = (storage: Storage) => async (url: RequestInfo, options?: Object): Promise<Response> => {
+export const authnFetch = (storage: AsyncStorage) => async (url: RequestInfo, options?: Object): Promise<Response> => {
   const session = await getSession(storage)
   if (session && await shouldShareCredentials(storage)(url)) {
     return fetchWithCredentials(session, url, options)
@@ -25,7 +25,7 @@ export const authnFetch = (storage: Storage) => async (url: RequestInfo, options
     })
 }
 
-const shouldShareCredentials = (storage: Storage) => async (url: RequestInfo): Promise<boolean> => {
+const shouldShareCredentials = (storage: AsyncStorage) => async (url: RequestInfo): Promise<boolean> => {
   const session = await getSession(storage)
   if (!session) {
     return false

--- a/src/authn-fetch.js
+++ b/src/authn-fetch.js
@@ -16,7 +16,7 @@ export const authnFetch = (storage: AsyncStorage) => async (url: RequestInfo, op
   return fetch(url, options)
     .then(async (resp) => {
       if (resp.status === 401) {
-        updateHostFromResponse(storage)(resp)
+        await updateHostFromResponse(storage)(resp)
         if (session && await shouldShareCredentials(storage)(url)) {
           return fetchWithCredentials(session, url, options)
         }

--- a/src/authn-fetch.js
+++ b/src/authn-fetch.js
@@ -13,16 +13,14 @@ export const authnFetch = (storage: AsyncStorage) => async (url: RequestInfo, op
   if (session && await shouldShareCredentials(storage)(url)) {
     return fetchWithCredentials(session, url, options)
   }
-  return fetch(url, options)
-    .then(async (resp) => {
-      if (resp.status === 401) {
-        await updateHostFromResponse(storage)(resp)
-        if (session && await shouldShareCredentials(storage)(url)) {
-          return fetchWithCredentials(session, url, options)
-        }
-      }
-      return resp
-    })
+  const resp = await fetch(url, options)
+  if (resp.status === 401) {
+    await updateHostFromResponse(storage)(resp)
+    if (session && await shouldShareCredentials(storage)(url)) {
+      return fetchWithCredentials(session, url, options)
+    }
+  }
+  return resp
 }
 
 const shouldShareCredentials = (storage: AsyncStorage) => async (url: RequestInfo): Promise<boolean> => {

--- a/src/hosts.js
+++ b/src/hosts.js
@@ -2,7 +2,6 @@
 /* global RequestInfo, Request, Response, URL */
 import { getSession } from './session'
 import type { AsyncStorage } from './storage'
-import { getData, updateStorage } from './storage'
 import type { Auth } from './types'
 import * as WebIdOidc from './webid-oidc'
 import * as WebIdTls from './webid-tls'
@@ -27,7 +26,7 @@ export const getHost = (storage: AsyncStorage) => async (url: RequestInfo): Prom
   if (session && hostNameFromRequestInfo(session.idp) === requestHostName) {
     return { url: requestHostName, authType: session.authType }
   }
-  const { hosts } = getData(storage)
+  const { hosts } = storage.getData()
   if (!hosts) {
     return null
   }
@@ -35,7 +34,7 @@ export const getHost = (storage: AsyncStorage) => async (url: RequestInfo): Prom
 }
 
 export const saveHost = (storage: AsyncStorage) => ({ url, authType }: host): host => {
-  updateStorage(storage, (data) => ({
+  storage.update((data) => ({
     ...data,
     hosts: {
       ...data.hosts,

--- a/src/hosts.js
+++ b/src/hosts.js
@@ -21,9 +21,9 @@ export const hostNameFromRequestInfo = (url: RequestInfo): string => {
   return _url.host
 }
 
-export const getHost = (storage: Storage) => (url: RequestInfo): ?host => {
+export const getHost = (storage: Storage) => async (url: RequestInfo): Promise<?host> => {
   const requestHostName = hostNameFromRequestInfo(url)
-  const session = getSession(storage)
+  const session = await getSession(storage)
   if (session && hostNameFromRequestInfo(session.idp) === requestHostName) {
     return { url: requestHostName, authType: session.authType }
   }

--- a/src/hosts.js
+++ b/src/hosts.js
@@ -1,7 +1,7 @@
 // @flow
 /* global RequestInfo, Request, Response, URL */
 import { getSession } from './session'
-import type { Storage } from './storage'
+import type { AsyncStorage } from './storage'
 import { getData, updateStorage } from './storage'
 import type { Auth } from './types'
 import * as WebIdOidc from './webid-oidc'
@@ -21,7 +21,7 @@ export const hostNameFromRequestInfo = (url: RequestInfo): string => {
   return _url.host
 }
 
-export const getHost = (storage: Storage) => async (url: RequestInfo): Promise<?host> => {
+export const getHost = (storage: AsyncStorage) => async (url: RequestInfo): Promise<?host> => {
   const requestHostName = hostNameFromRequestInfo(url)
   const session = await getSession(storage)
   if (session && hostNameFromRequestInfo(session.idp) === requestHostName) {
@@ -34,7 +34,7 @@ export const getHost = (storage: Storage) => async (url: RequestInfo): Promise<?
   return hosts[requestHostName] || null
 }
 
-export const saveHost = (storage: Storage) => ({ url, authType }: host): host => {
+export const saveHost = (storage: AsyncStorage) => ({ url, authType }: host): host => {
   updateStorage(storage, (data) => ({
     ...data,
     hosts: {
@@ -45,7 +45,7 @@ export const saveHost = (storage: Storage) => ({ url, authType }: host): host =>
   return { url, authType }
 }
 
-export const updateHostFromResponse = (storage: Storage) => (resp: Response): void => {
+export const updateHostFromResponse = (storage: AsyncStorage) => (resp: Response): void => {
   let authType
   if (WebIdOidc.requiresAuth(resp)) {
     authType = 'WebID-OIDC'

--- a/src/hosts.js
+++ b/src/hosts.js
@@ -26,15 +26,15 @@ export const getHost = (storage: AsyncStorage) => async (url: RequestInfo): Prom
   if (session && hostNameFromRequestInfo(session.idp) === requestHostName) {
     return { url: requestHostName, authType: session.authType }
   }
-  const { hosts } = storage.getData()
+  const { hosts } = await storage.getData()
   if (!hosts) {
     return null
   }
   return hosts[requestHostName] || null
 }
 
-export const saveHost = (storage: AsyncStorage) => ({ url, authType }: host): host => {
-  storage.update((data) => ({
+export const saveHost = (storage: AsyncStorage) => async ({ url, authType }: host): Promise<host> => {
+  await storage.update((data) => ({
     ...data,
     hosts: {
       ...data.hosts,
@@ -44,7 +44,7 @@ export const saveHost = (storage: AsyncStorage) => ({ url, authType }: host): ho
   return { url, authType }
 }
 
-export const updateHostFromResponse = (storage: AsyncStorage) => (resp: Response): void => {
+export const updateHostFromResponse = (storage: AsyncStorage) => async (resp: Response): Promise<void> => {
   let authType
   if (WebIdOidc.requiresAuth(resp)) {
     authType = 'WebID-OIDC'
@@ -56,6 +56,6 @@ export const updateHostFromResponse = (storage: AsyncStorage) => (resp: Response
 
   const hostName = hostNameFromRequestInfo(resp.url)
   if (authType) {
-    saveHost(storage)({ url: hostName, authType })
+    await saveHost(storage)({ url: hostName, authType })
   }
 }

--- a/src/session.js
+++ b/src/session.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Storage } from './storage'
+import type { AsyncStorage } from './storage'
 import { getData, updateStorage } from './storage'
 import type { WebIdTls, WebIdOidc } from './types'
 
@@ -22,12 +22,12 @@ export type session =
   | webIdTlsSession
   | webIdOidcSession
 
-export const getSession = async (storage: Storage): Promise<?session> =>
+export const getSession = async (storage: AsyncStorage): Promise<?session> =>
   getData(storage).session || null
 
-export const saveSession = (storage: Storage) => async (session: session): Promise<session> =>
+export const saveSession = (storage: AsyncStorage) => async (session: session): Promise<session> =>
   updateStorage(storage, data => ({ ...data, session })).session
 
-export const clearSession = async (storage: Storage): Promise<void> => {
+export const clearSession = async (storage: AsyncStorage): Promise<void> => {
   updateStorage(storage, data => ({ ...data, session: null }))
 }

--- a/src/session.js
+++ b/src/session.js
@@ -1,7 +1,6 @@
 // @flow
 
 import type { AsyncStorage } from './storage'
-import { getData, updateStorage } from './storage'
 import type { WebIdTls, WebIdOidc } from './types'
 
 export type webIdTlsSession =
@@ -23,11 +22,11 @@ export type session =
   | webIdOidcSession
 
 export const getSession = async (storage: AsyncStorage): Promise<?session> =>
-  getData(storage).session || null
+  storage.getData().session || null
 
 export const saveSession = (storage: AsyncStorage) => async (session: session): Promise<session> =>
-  updateStorage(storage, data => ({ ...data, session })).session
+  storage.update(data => ({ ...data, session })).session
 
 export const clearSession = async (storage: AsyncStorage): Promise<void> => {
-  updateStorage(storage, data => ({ ...data, session: null }))
+  storage.update(data => ({ ...data, session: null }))
 }

--- a/src/session.js
+++ b/src/session.js
@@ -22,12 +22,12 @@ export type session =
   | webIdTlsSession
   | webIdOidcSession
 
-export const getSession = (storage: Storage): ?session =>
+export const getSession = async (storage: Storage): Promise<?session> =>
   getData(storage).session || null
 
-export const saveSession = (storage: Storage) => (session: session): session =>
+export const saveSession = (storage: Storage) => async (session: session): Promise<session> =>
   updateStorage(storage, data => ({ ...data, session })).session
 
-export const clearSession = (storage: Storage): void => {
+export const clearSession = async (storage: Storage): Promise<void> => {
   updateStorage(storage, data => ({ ...data, session: null }))
 }

--- a/src/session.js
+++ b/src/session.js
@@ -21,12 +21,16 @@ export type session =
   | webIdTlsSession
   | webIdOidcSession
 
-export const getSession = async (storage: AsyncStorage): Promise<?session> =>
-  storage.getData().session || null
+export const getSession = async (storage: AsyncStorage): Promise<?session> => {
+  const data = await storage.getData()
+  return data.session || null
+}
 
-export const saveSession = (storage: AsyncStorage) => async (session: session): Promise<session> =>
-  storage.update(data => ({ ...data, session })).session
+export const saveSession = (storage: AsyncStorage) => async (session: session): Promise<session> => {
+  const updated = await storage.update(data => ({ ...data, session }))
+  return updated.session
+}
 
 export const clearSession = async (storage: AsyncStorage): Promise<void> => {
-  storage.update(data => ({ ...data, session: null }))
+  await storage.update(data => ({ ...data, session: null }))
 }

--- a/src/storage.js
+++ b/src/storage.js
@@ -11,6 +11,23 @@ export class AsyncStorage {
       this.setItem(key, hash[key])
     }
   }
+
+  /**
+   * Gets the deserialized stored data
+   */
+  getData (): Object {
+    return JSON.parse(this.getItem(NAMESPACE) || '{}')
+  }
+
+  /**
+   * Updates the storage without mutating the intermediate representation
+   */
+  update (update: (Object) => Object): Object {
+    const currentData = this.getData()
+    const newData = update(currentData)
+    this.setItem(NAMESPACE, JSON.stringify(newData))
+    return newData
+  }
 }
 
 export class MemoryStorage extends AsyncStorage {
@@ -52,20 +69,4 @@ export const defaultStorage = (): AsyncStorage => {
     `Creating a (not very useful) in-memory storage object as the default storage interface.`
   )
   return new MemoryStorage()
-}
-
-/**
- * Gets the deserialized stored data
- */
-export const getData = (store: AsyncStorage) =>
-  JSON.parse(store.getItem(NAMESPACE) || '{}')
-
-/**
- * Updates a Storage object without mutating its intermediate representation.
- */
-export const updateStorage = (store: AsyncStorage, update: (Object) => Object): Object => {
-  const currentData = getData(store)
-  const newData = update(currentData)
-  store.setItem(NAMESPACE, JSON.stringify(newData))
-  return newData
 }

--- a/src/storage.js
+++ b/src/storage.js
@@ -3,54 +3,54 @@
 export const NAMESPACE = 'solid-auth-client'
 
 export class AsyncStorage {
-  getItem (key: string): ?string {}
-  setItem (key: string, val: string): void {}
-  getItems (): { [string]: string } { return {} }
-  setItems (hash: { [string]: string }): void {
-    for (const key in hash) {
-      this.setItem(key, hash[key])
-    }
+  async getItem (key: string): Promise<?string> {}
+  async setItem (key: string, val: string): Promise<void> {}
+  async getItems (): Promise<{ [string]: string }> { throw new Error() }
+  async setItems (hash: { [string]: string }): Promise<void> {
+    const setters = Object.keys(hash).map(k => this.setItem(k, hash[k]))
+    await Promise.all(setters)
   }
 
   /**
    * Gets the deserialized stored data
    */
-  getData (): Object {
-    return JSON.parse(this.getItem(NAMESPACE) || '{}')
+  async getData (): Promise<Object> {
+    const item = await this.getItem(NAMESPACE)
+    return item ? JSON.parse(item) : {}
   }
 
   /**
    * Updates the storage without mutating the intermediate representation
    */
-  update (update: (Object) => Object): Object {
-    const currentData = this.getData()
+  async update (update: (Object) => Object): Promise<Object> {
+    const currentData = await this.getData()
     const newData = update(currentData)
-    this.setItem(NAMESPACE, JSON.stringify(newData))
+    await this.setItem(NAMESPACE, JSON.stringify(newData))
     return newData
   }
 }
 
 export class MemoryStorage extends AsyncStorage {
   store = {}
-  getItem (key: string): ?string {
+  async getItem (key: string): Promise<?string> {
     return key in this.store ? this.store[key] : null
   }
-  setItem (key: string, val: string) {
+  async setItem (key: string, val: string): Promise<void> {
     this.store[key] = val
   }
-  getItems (): { [string]: string } {
+  async getItems (): Promise<{ [string]: string }> {
     return this.store
   }
 }
 
 export class LocalStorage extends AsyncStorage {
-  getItem (key: string): ?string {
+  async getItem (key: string): Promise<?string> {
     return window.localStorage.getItem(key)
   }
-  setItem (key: string, val: string) {
+  async setItem (key: string, val: string): Promise<void> {
     window.localStorage.setItem(key, val)
   }
-  getItems (): { [string]: string } {
+  async getItems (): Promise<{ [string]: string }> {
     const hash = {}
     for (var i = 0; i < window.localStorage.length; i++) {
       const key = window.localStorage.key(i)

--- a/src/storage.js
+++ b/src/storage.js
@@ -2,50 +2,68 @@
 
 export const NAMESPACE = 'solid-auth-client'
 
-export interface StorageInterface {
-  getItem (key: string): ?string;
-  setItem (key: string, val: string): void;
-}
-
-export type Storage = Storage | StorageInterface
-
-export const memStorage = (): Storage => {
-  const store = {}
-  store.getItem = (key: string): ?string => {
-    if (typeof store[key] === 'undefined') return null
-    return store[key]
-  }
-  store.setItem = (key: string, val: string) => {
-    store[key] = val
-  }
-  return store
-}
-
-export const defaultStorage = () => {
-  try {
-    if (window && window.localStorage) {
-      return window.localStorage
+export class AsyncStorage {
+  getItem (key: string): ?string {}
+  setItem (key: string, val: string): void {}
+  getItems (): { [string]: string } { return {} }
+  setItems (hash: { [string]: string }): void {
+    for (const key in hash) {
+      this.setItem(key, hash[key])
     }
-  } catch (e) {
-    if (!(e instanceof ReferenceError)) { throw e }
+  }
+}
+
+export class MemoryStorage extends AsyncStorage {
+  store = {}
+  getItem (key: string): ?string {
+    return key in this.store ? this.store[key] : null
+  }
+  setItem (key: string, val: string) {
+    this.store[key] = val
+  }
+  getItems (): { [string]: string } {
+    return this.store
+  }
+}
+
+export class LocalStorage extends AsyncStorage {
+  getItem (key: string): ?string {
+    return window.localStorage.getItem(key)
+  }
+  setItem (key: string, val: string) {
+    window.localStorage.setItem(key, val)
+  }
+  getItems (): { [string]: string } {
+    const hash = {}
+    for (var i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i)
+      hash[key] = window.localStorage.getItem(key)
+    }
+    return hash
+  }
+}
+
+export const defaultStorage = (): AsyncStorage => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return new LocalStorage()
   }
   console.warn(
     `'window.localStorage' unavailable.  ` +
     `Creating a (not very useful) in-memory storage object as the default storage interface.`
   )
-  return memStorage()
+  return new MemoryStorage()
 }
 
 /**
  * Gets the deserialized stored data
  */
-export const getData = (store: Storage) =>
+export const getData = (store: AsyncStorage) =>
   JSON.parse(store.getItem(NAMESPACE) || '{}')
 
 /**
  * Updates a Storage object without mutating its intermediate representation.
  */
-export const updateStorage = (store: Storage, update: (Object) => Object): Object => {
+export const updateStorage = (store: AsyncStorage, update: (Object) => Object): Object => {
   const currentData = getData(store)
   const newData = update(currentData)
   store.setItem(NAMESPACE, JSON.stringify(newData))

--- a/src/storage.spec.js
+++ b/src/storage.spec.js
@@ -2,14 +2,14 @@
 /* eslint-env mocha */
 /* global expect */
 
-import type { Storage } from './storage'
+import type { AsyncStorage } from './storage'
 import { defaultStorage } from './storage'
 
 describe('defaultStorage', () => {
-  it('returns a memStorage if window is not available', () => {
+  it('returns a MemoryStorage if window is not available', () => {
     const { window } = global
     delete global.window
-    const storage: Storage = defaultStorage()
+    const storage: AsyncStorage = defaultStorage()
     storage.setItem('foo', 'bar')
     expect(storage.getItem('foo')).toBe('bar')
     global.window = window

--- a/src/storage.spec.js
+++ b/src/storage.spec.js
@@ -6,12 +6,12 @@ import type { AsyncStorage } from './storage'
 import { defaultStorage } from './storage'
 
 describe('defaultStorage', () => {
-  it('returns a MemoryStorage if window is not available', () => {
+  it('returns a MemoryStorage if window is not available', async () => {
     const { window } = global
     delete global.window
     const storage: AsyncStorage = defaultStorage()
-    storage.setItem('foo', 'bar')
-    expect(storage.getItem('foo')).toBe('bar')
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
     global.window = window
   })
 })

--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -8,7 +8,7 @@ import type { loginOptions } from './api'
 import { currentUrl, clearHashFragment, navigateTo } from './browser-util'
 import type { webIdOidcSession } from './session'
 import type { AsyncStorage } from './storage'
-import { defaultStorage, getData, updateStorage } from './storage'
+import { defaultStorage } from './storage'
 
 export const login = (idp: string, options: loginOptions): Promise<any> =>
   getRegisteredRp(idp, options)
@@ -60,12 +60,12 @@ export const getRegisteredRp = (idp: string, options: loginOptions): Promise<Rel
     })
 
 const getStoredRp = (storage: AsyncStorage): Promise<?RelyingParty> => {
-  const { rpConfig } = getData(storage)
+  const { rpConfig } = storage.getData()
   return rpConfig ? RelyingParty.from(rpConfig) : Promise.resolve(null)
 }
 
 const storeRp = (storage: AsyncStorage, idp: string, rp: RelyingParty): RelyingParty => {
-  updateStorage(storage, data => ({
+  storage.update(data => ({
     ...data,
     rpConfig: rp
   }))

--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -21,9 +21,9 @@ export const login = (idp: string, options: loginOptions): Promise<any> =>
 
 export const currentSession = (storage: AsyncStorage = defaultStorage()): Promise<?webIdOidcSession> => {
   return getStoredRp(storage)
-    .then(rp => {
+    .then(async rp => {
       if (!rp) { return null }
-      return rp.validateResponse(currentUrl() || '', storage.getItems())
+      return rp.validateResponse(currentUrl() || '', await storage.getItems())
     })
     .then(resp => {
       if (!resp) { return null }
@@ -59,9 +59,9 @@ export const getRegisteredRp = (idp: string, options: loginOptions): Promise<Rel
         .then(rp => storeRp(options.storage, idp, rp))
     })
 
-const getStoredRp = (storage: AsyncStorage): Promise<?RelyingParty> => {
-  const { rpConfig } = storage.getData()
-  return rpConfig ? RelyingParty.from(rpConfig) : Promise.resolve(null)
+const getStoredRp = async (storage: AsyncStorage): Promise<?RelyingParty> => {
+  const { rpConfig } = await storage.getData()
+  return rpConfig ? RelyingParty.from(rpConfig) : null
 }
 
 const storeRp = (storage: AsyncStorage, idp: string, rp: RelyingParty): RelyingParty => {
@@ -72,7 +72,7 @@ const storeRp = (storage: AsyncStorage, idp: string, rp: RelyingParty): RelyingP
   return rp
 }
 
-const registerRp = (idp: string, { storage, redirectUri }: loginOptions): Promise<RelyingParty> => {
+const registerRp = async (idp: string, { storage, redirectUri }: loginOptions): Promise<RelyingParty> => {
   const responseType = 'id_token token'
   const registration = {
     issuer: idp,
@@ -88,15 +88,15 @@ const registerRp = (idp: string, { storage, redirectUri }: loginOptions): Promis
         response_type: responseType
       }
     },
-    store: storage.getItems()
+    store: await storage.getItems()
   }
   return RelyingParty.register(idp, registration, options)
 }
 
 const sendAuthRequest = async (rp: RelyingParty, { redirectUri, storage }: loginOptions): Promise<void> => {
-  const session = storage.getItems()
+  const session = await storage.getItems()
   const url = await rp.createRequest({ redirect_uri: redirectUri }, session)
-  storage.setItems(session)
+  await storage.setItems(session)
   navigateTo(url)
 }
 

--- a/src/webid-tls.js
+++ b/src/webid-tls.js
@@ -5,10 +5,11 @@ import 'isomorphic-fetch'
 import * as authorization from 'auth-header'
 import type { webIdTlsSession } from './session'
 
-export const login = (idp: string): Promise<?webIdTlsSession> =>
-  fetch(idp, { method: 'HEAD', credentials: 'include' })
-    .then(resp => resp.headers.get('user'))
-    .then(webId => webId ? { authType: 'WebID-TLS', idp, webId } : null)
+export const login = async (idp: string): Promise<?webIdTlsSession> => {
+  const resp = await fetch(idp, { method: 'HEAD', credentials: 'include' })
+  const webId = resp.headers.get('user')
+  return webId ? { authType: 'WebID-TLS', idp, webId } : null
+}
 
 export const requiresAuth = (resp: Response): boolean => {
   if (resp.status !== 401) { return false }

--- a/yarn.lock
+++ b/yarn.lock
@@ -440,6 +440,16 @@ babel-helper-regex@^6.24.1:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
@@ -498,6 +508,10 @@ babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
 
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
@@ -513,6 +527,14 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
 
 babel-plugin-transform-class-properties@^6.24.1:
   version "6.24.1"


### PR DESCRIPTION
This pull request introduces the `AsyncStorage` class, and makes all storage methods (`getItem`, `setItem`, …) asynchronous.