### PR TITLE
Add login, logout, and session events

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ authenticate scheme.
 SolidAuthClient.fetch: (url: RequestInfo, options?: Object) => Promise<Response>
 ```
 
+
+### Events
+
+`SolidAuthClient` implements [`EventEmitter`](https://nodejs.org/api/events.html).
+It currently emits the following events:
+- `login (session: Session)` when a user logs in
+- `logout ()` when a user logs out
+- `session (session: Session | null)` when a user logs in or out
+
 ### types
 
 ```

--- a/demo/components/App.js
+++ b/demo/components/App.js
@@ -1,50 +1,18 @@
 // @flow
-import 'isomorphic-fetch'
 import React from 'react'
 
-import Copy from './Copy'
 import Nav from './Nav'
+import Copy from './Copy'
 import PersonalInfo from './PersonalInfo'
 import Footer from './Footer'
 
-import type { Session } from '../../src/session'
-import SolidAuthClient from '../../src/'
+const App = () => (
+  <div>
+    <Nav />
+    <Copy />
+    <PersonalInfo />
+    <Footer />
+  </div>
+)
 
-export default class App extends React.Component<Object, Object> {
-  state: { session: ?Session } = { session: null }
-
-  saveCredentials = (session: Session): void => {
-    this.setState({ session })
-  }
-
-  onClickLogIn = () =>
-    SolidAuthClient.popupLogin({
-      popupUri: process.env.POPUP_URI
-    }).then(this.saveCredentials)
-
-  onClickLogOut = () =>
-    SolidAuthClient.logout().then(() => {
-      this.setState({ session: null })
-    })
-
-  constructor(props: {}) {
-    super(props)
-    SolidAuthClient.currentSession().then(this.saveCredentials)
-  }
-
-  render() {
-    const loggedIn = this.state.session !== null
-    return (
-      <div>
-        <Nav
-          loggedIn={loggedIn}
-          onClickLogIn={this.onClickLogIn}
-          onClickLogOut={this.onClickLogOut}
-        />
-        <Copy loggedIn={loggedIn} />
-        <PersonalInfo session={this.state.session} />
-        <Footer />
-      </div>
-    )
-  }
-}
+export default App

--- a/demo/components/App.js
+++ b/demo/components/App.js
@@ -1,14 +1,17 @@
 // @flow
 import React from 'react'
 
-import Nav from './Nav'
+import LoginButton from './LoginButton'
 import Copy from './Copy'
 import PersonalInfo from './PersonalInfo'
 import Footer from './Footer'
 
 const App = () => (
   <div>
-    <Nav />
+    <nav>
+      <h1>Solid Auth Client Demo</h1>
+      <LoginButton />
+    </nav>
     <Copy />
     <PersonalInfo />
     <Footer />

--- a/demo/components/Copy.js
+++ b/demo/components/Copy.js
@@ -1,12 +1,24 @@
 import React from 'react'
 
-const Copy = ({ loggedIn }: { loggedIn: boolean }) => (
-  <p>
-    This is a simple demo of the Solid Auth Client. You're currently
-    {loggedIn
-      ? ' logged in'
-      : ' anonymous. Click "Log in" to authenticate and see some information about yourself'}.
-  </p>
-)
+import SolidAuthClient from '../../src/'
 
-export default Copy
+export default class Copy extends React.Component<Object, Object> {
+  constructor(props) {
+    super(props)
+    SolidAuthClient.trackSession(session =>
+      this.setState({ loggedIn: !!session })
+    )
+  }
+
+  render() {
+    const { loggedIn } = this.state
+    return (
+      <p>
+        This is a simple demo of the Solid Auth Client. You're currently
+        {loggedIn
+          ? ' logged in'
+          : ' anonymous. Click "Log in" to authenticate and see some information about yourself'}.
+      </p>
+    )
+  }
+}

--- a/demo/components/LoginButton.js
+++ b/demo/components/LoginButton.js
@@ -3,7 +3,7 @@ import React from 'react'
 
 import SolidAuthClient from '../../src/'
 
-export default class Nav extends React.Component<Object, Object> {
+export default class LoginButton extends React.Component<Object, Object> {
   constructor(props: {}) {
     super(props)
     SolidAuthClient.trackSession(session =>
@@ -22,16 +22,10 @@ export default class Nav extends React.Component<Object, Object> {
   }
 
   render() {
-    const { loggedIn } = this.state
-    return (
-      <nav>
-        <h1>Solid Auth Client Demo</h1>
-        {loggedIn ? (
-          <button onClick={this.logout}>Log out</button>
-        ) : (
-          <button onClick={this.login}>Log in</button>
-        )}
-      </nav>
+    return this.state.loggedIn ? (
+      <button onClick={this.logout}>Log out</button>
+    ) : (
+      <button onClick={this.login}>Log in</button>
     )
   }
 }

--- a/demo/components/Nav.js
+++ b/demo/components/Nav.js
@@ -1,21 +1,37 @@
 // @flow
 import React from 'react'
 
-type propTypes = {
-  loggedIn: boolean,
-  onClickLogIn: (event: Event) => any,
-  onClickLogOut: (event: Event) => any
+import SolidAuthClient from '../../src/'
+
+export default class Nav extends React.Component<Object, Object> {
+  constructor(props: {}) {
+    super(props)
+    SolidAuthClient.trackSession(session =>
+      this.setState({ loggedIn: !!session })
+    )
+  }
+
+  login() {
+    SolidAuthClient.popupLogin({
+      popupUri: process.env.POPUP_URI
+    })
+  }
+
+  logout() {
+    SolidAuthClient.logout()
+  }
+
+  render() {
+    const { loggedIn } = this.state
+    return (
+      <nav>
+        <h1>Solid Auth Client Demo</h1>
+        {loggedIn ? (
+          <button onClick={this.logout}>Log out</button>
+        ) : (
+          <button onClick={this.login}>Log in</button>
+        )}
+      </nav>
+    )
+  }
 }
-
-const Nav = ({ loggedIn, onClickLogIn, onClickLogOut }: propTypes) => (
-  <nav>
-    <h1>Solid Auth Client Demo</h1>
-    {loggedIn ? (
-      <button onClick={onClickLogOut}>Log out</button>
-    ) : (
-      <button onClick={onClickLogIn}>Log in</button>
-    )}
-  </nav>
-)
-
-export default Nav

--- a/demo/components/PersonalInfo.js
+++ b/demo/components/PersonalInfo.js
@@ -1,5 +1,4 @@
 // @flow
-import 'isomorphic-fetch'
 import React from 'react'
 
 import SolidAuthClient from '../../src/'

--- a/demo/components/PersonalInfo.js
+++ b/demo/components/PersonalInfo.js
@@ -3,21 +3,23 @@ import 'isomorphic-fetch'
 import React from 'react'
 
 import SolidAuthClient from '../../src/'
-import type { Session } from '../../src/session'
 
 type Profile = {
   'foaf:name': ?{ '@value': string }
 }
 
 export default class PersonalInfo extends React.Component<Object, Object> {
-  props: { session: ?Session }
-
-  defaultProps = {
-    session: null
-  }
-
-  state: { profile: Profile } = {
-    profile: { 'foaf:name': null }
+  constructor(props: {}) {
+    super(props)
+    SolidAuthClient.trackSession(async session => {
+      let webId, profile, name
+      if (session) {
+        webId = session.webId
+        profile = await this.fetchProfile(webId)
+        name = profile['foaf:name'] && profile['foaf:name']['@value']
+      }
+      this.setState({ webId, name })
+    })
   }
 
   fetchProfile = (webId: string): Promise<Profile> => {
@@ -31,24 +33,13 @@ export default class PersonalInfo extends React.Component<Object, Object> {
     }).then(resp => resp.json())
   }
 
-  saveProfile = (profile: Profile): void => this.setState({ profile })
-
-  componentWillReceiveProps(props: { session: ?Session }) {
-    if (props.session) {
-      this.fetchProfile(props.session.webId).then(this.saveProfile)
-    }
-  }
-
   render() {
-    const { session } = this.props
-    const name = this.state.profile['foaf:name']
-      ? this.state.profile['foaf:name']['@value']
-      : 'unnamed person'
-    return session ? (
+    const { webId, name } = this.state
+    return webId ? (
       <div>
         Hey there, <span>{name}</span>! Your WebID is:{' '}
-        <a href={session.webId} target="_blank">
-          <code>{session.webId}</code>
+        <a href={webId} target="_blank">
+          <code>{webId}</code>
         </a>
       </div>
     ) : null

--- a/package-lock.json
+++ b/package-lock.json
@@ -6644,6 +6644,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
@@ -14689,7 +14690,8 @@
     "whatwg-fetch": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@trust/oidc-rp": "^0.4.3",
     "auth-header": "^0.3.1",
     "commander": "^2.11.0",
-    "isomorphic-fetch": "^2.2.1",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/src/__test__/solid-auth-client.spec.js
+++ b/src/__test__/solid-auth-client.spec.js
@@ -326,6 +326,56 @@ describe('currentSession', () => {
   })
 })
 
+describe('trackSession', () => {
+  it('yields null if there is no active session', async () => {
+    expect.assertions(2)
+    const callback = jest.fn()
+    await instance.trackSession(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith(null)
+  })
+
+  it('yields an active session', async () => {
+    expect.assertions(2)
+    const session = {}
+    await saveSession(window.localStorage)(session)
+
+    const callback = jest.fn()
+    await instance.trackSession(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith(session)
+  })
+
+  it('calls the callback on login', async () => {
+    expect.assertions(4)
+
+    const callback = jest.fn()
+    await instance.trackSession(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith(null)
+
+    const session = {}
+    instance.emit('session', session)
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith(session)
+  })
+
+  it('calls the callback on logout', async () => {
+    expect.assertions(4)
+    const session = {}
+    await saveSession(window.localStorage)(session)
+
+    const callback = jest.fn()
+    await instance.trackSession(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith(session)
+
+    await instance.logout()
+    expect(callback).toHaveBeenCalledTimes(2)
+    expect(callback).toHaveBeenLastCalledWith(null)
+  })
+})
+
 describe('logout', () => {
   describe('WebID-OIDC', () => {
     let expectedIdToken, expectedAccessToken

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -56,6 +56,8 @@ export default class SolidAuthClient extends EventEmitter {
       childWindow,
       options
     )
+    this.emit('login', session)
+    this.emit('session', session)
     return session
   }
 

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -1,5 +1,6 @@
 // @flow
 /* global RequestInfo, Response */
+import EventEmitter from 'events'
 import { authnFetch } from './authn-fetch'
 import { openIdpSelector, startPopupServer } from './popup'
 import type { Session } from './session'
@@ -24,7 +25,7 @@ const defaultLoginOptions = (): loginOptions => {
   }
 }
 
-export default class SolidAuthClient {
+export default class SolidAuthClient extends EventEmitter {
   fetch(url: RequestInfo, options?: Object): Promise<Response> {
     return authnFetch(defaultStorage())(url, options)
   }

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -71,6 +71,7 @@ export default class SolidAuthClient extends EventEmitter {
       }
       if (session) {
         this.emit('login', session)
+        this.emit('session', session)
         await saveSession(storage)(session)
       }
     }
@@ -83,6 +84,7 @@ export default class SolidAuthClient extends EventEmitter {
       try {
         await WebIdOidc.logout(storage)
         this.emit('logout')
+        this.emit('session', null)
       } catch (err) {
         console.warn('Error logging out:')
         console.error(err)

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -70,6 +70,7 @@ export default class SolidAuthClient extends EventEmitter {
         console.error(err)
       }
       if (session) {
+        this.emit('login', session)
         await saveSession(storage)(session)
       }
     }

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -78,6 +78,12 @@ export default class SolidAuthClient extends EventEmitter {
     return session
   }
 
+  async trackSession(callback: Function): Promise<void> {
+    /* eslint-disable standard/no-callback-literal */
+    callback(await this.currentSession())
+    this.on('session', callback)
+  }
+
   async logout(storage: AsyncStorage = defaultStorage()): Promise<void> {
     const session = await getSession(storage)
     if (session) {

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -82,6 +82,7 @@ export default class SolidAuthClient extends EventEmitter {
     if (session) {
       try {
         await WebIdOidc.logout(storage)
+        this.emit('logout')
       } catch (err) {
         console.warn('Error logging out:')
         console.error(err)


### PR DESCRIPTION
This pull request extends SolidAuthClient with 3 events:
- `login (session)` when a user logs in
- `logout` when a user logs out
- `session (session | null)` when a user logs in or out

These events can be listened to through `SolidAuthClient.on`.

In addition, this PR adds a `trackSession` method, which will pass the current session and any changes thereto through the provided callback.

Finally, I've recoded the demo application to use these events, which simplifies that code.