### PR TITLE
Expose the client as window.solid.auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,32 @@ and then use the ES6 module (`import { login, currentUser, logout } from
 'solid-auth-client'`), or grab the transpiled UMD bundle from
 `node_modules/solid-auth-client/dist-lib/solid-auth-client.bundle.js`.
 
+## Usage
+In the browser, the library is accessible through `solid.auth`:
+```html
+<script src="https://solid.github.io/solid-auth-client/dist/solid-auth-client.bundle.js"></script>
+<script>
+solid.auth.trackSession(session => {
+  if (!session)
+    console.log('The user is not logged in')
+  else
+    console.log(`The user is ${session.webId}`)
+})
+</script>
+```
+
+In Node.js, the library can be included as follows:
+```javascript
+const { default: auth } = require('solid-auth-client')
+
+auth.trackSession(session => {
+  if (!session)
+    console.log('The user is not logged in')
+  else
+    console.log(`The user is ${session.webId}`)
+})
+```
+
 ## API
 
 *This API doc uses [flow](https://flow.org/) type annotations for clarity.
@@ -36,7 +62,7 @@ functions.  You don't have to know anything about flow.*
 ### `login`
 
 ```
-SolidAuthClient.login (idp: string, {
+SolidAuthClient#login (idp: string, {
   callbackUri?: string,
   storage?: Storage
 }): Promise<?session>
@@ -66,7 +92,7 @@ Options:
 ### `popupLogin`
 
 ```
-SolidAuthClient.popupLogin({
+SolidAuthClient#popupLogin({
   popupUri: ?string,
   storage: AsyncStorage
 }): Promise<?session>
@@ -78,7 +104,7 @@ See [Logging in via the popup app](#Logging-in-via-the-popup-app).
 ### `currentSession`
 
 ```
-SolidAuthClient.currentSession (storage?: Storage): Promise<?session>
+SolidAuthClient#currentSession (storage?: Storage): Promise<?session>
 ```
 
 Finds the current session, and returns it if it is still active, otherwise
@@ -87,7 +113,7 @@ Finds the current session, and returns it if it is still active, otherwise
 ### `logout`
 
 ```
-SolidAuthClient.logout (storage?: Storage): Promise<void>
+SolidAuthClient#logout (storage?: Storage): Promise<void>
 ```
 
 Clears the active user session.
@@ -100,7 +126,7 @@ encounters a `401` with a `WWW-Authenticate` header which matches a recognized
 authenticate scheme.
 
 ```
-SolidAuthClient.fetch: (url: RequestInfo, options?: Object) => Promise<Response>
+SolidAuthClient#fetch: (url: RequestInfo, options?: Object) => Promise<Response>
 ```
 
 
@@ -146,7 +172,7 @@ $ solid-auth-client generate-popup # ["My App Name"] [my-app-popup.html]
 
 2. Place the popup file on your server (say at `https://localhost:8080/popup.html`).
 
-3. From within your own app, call `SolidAuthClient.popupLogin({ popupUri: 'https://localhost:8080/popup.html' })`.
+3. From within your own app, call `solid.auth.popupLogin({ popupUri: 'https://localhost:8080/popup.html' })`.
 
 ## Developing
 

--- a/demo/components/Copy.js
+++ b/demo/components/Copy.js
@@ -1,13 +1,11 @@
 import React from 'react'
 
-import SolidAuthClient from '../../src/'
+import auth from '../../src/'
 
 export default class Copy extends React.Component<Object, Object> {
   constructor(props) {
     super(props)
-    SolidAuthClient.trackSession(session =>
-      this.setState({ loggedIn: !!session })
-    )
+    auth.trackSession(session => this.setState({ loggedIn: !!session }))
   }
 
   render() {

--- a/demo/components/LoginButton.js
+++ b/demo/components/LoginButton.js
@@ -1,31 +1,21 @@
 // @flow
 import React from 'react'
 
-import SolidAuthClient from '../../src/'
+import auth from '../../src/'
+
+const popupUri = process.env.POPUP_URI
 
 export default class LoginButton extends React.Component<Object, Object> {
   constructor(props: {}) {
     super(props)
-    SolidAuthClient.trackSession(session =>
-      this.setState({ loggedIn: !!session })
-    )
-  }
-
-  login() {
-    SolidAuthClient.popupLogin({
-      popupUri: process.env.POPUP_URI
-    })
-  }
-
-  logout() {
-    SolidAuthClient.logout()
+    auth.trackSession(session => this.setState({ loggedIn: !!session }))
   }
 
   render() {
     return this.state.loggedIn ? (
-      <button onClick={this.logout}>Log out</button>
+      <button onClick={() => auth.logout()}>Log out</button>
     ) : (
-      <button onClick={this.login}>Log in</button>
+      <button onClick={() => auth.popupLogin({ popupUri })}>Log in</button>
     )
   }
 }

--- a/demo/components/PersonalInfo.js
+++ b/demo/components/PersonalInfo.js
@@ -1,7 +1,7 @@
 // @flow
 import React from 'react'
 
-import SolidAuthClient from '../../src/'
+import auth from '../../src/'
 
 type Profile = {
   'foaf:name': ?{ '@value': string }
@@ -10,7 +10,7 @@ type Profile = {
 export default class PersonalInfo extends React.Component<Object, Object> {
   constructor(props: {}) {
     super(props)
-    SolidAuthClient.trackSession(async session => {
+    auth.trackSession(async session => {
       let webId, profile, name
       if (session) {
         webId = session.webId
@@ -26,10 +26,12 @@ export default class PersonalInfo extends React.Component<Object, Object> {
       @prefix foaf http://xmlns.com/foaf/0.1/
       ${webId} { foaf:name }
     `
-    return SolidAuthClient.fetch('https://databox.me/,query', {
-      method: 'POST',
-      body: query
-    }).then(resp => resp.json())
+    return auth
+      .fetch('https://databox.me/,query', {
+        method: 'POST',
+        body: query
+      })
+      .then(resp => resp.json())
   }
 
   render() {

--- a/demo/index.js
+++ b/demo/index.js
@@ -6,13 +6,13 @@ import './index.css'
 
 import App from './components/App'
 
-import SolidAuthClient from '../src'
+import auth from '../src'
 
 // for demo/debug purposes
-window.SolidAuthClient = SolidAuthClient
+window.solid = { auth }
 console.log('Welcome to the solid-auth-client demo!')
 console.log(
-  'Check out window.SolidAuthClient to explore the interface at the code level.'
+  'Check out window.solid.auth to explore the interface at the code level.'
 )
 console.log(
   'If you find a bug please file it at https://github.com/solid/solid-auth-client/issues/'

--- a/popup-app/components/IdpCallback.js
+++ b/popup-app/components/IdpCallback.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 
-import SolidAuthClient from '../../src'
+import auth from '../../src'
 import { client } from '../../src/ipc'
 import { postMessageStorage } from '../../src/storage'
 
@@ -11,7 +11,7 @@ export default class IdpCallback extends Component {
 
   postSession = async () => {
     const storage = postMessageStorage(window.opener, this.props.appOrigin)
-    const session = await SolidAuthClient.currentSession(storage)
+    const session = await auth.currentSession(storage)
     return this.request({ method: 'foundSession', args: [session] })
   }
 

--- a/popup-app/components/IdpSelect.js
+++ b/popup-app/components/IdpSelect.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import SolidAuthClient from '../../src'
+import auth from '../../src'
 import { client } from '../../src/ipc'
 import { postMessageStorage } from '../../src/storage'
 
@@ -64,7 +64,7 @@ class IdpSelect extends React.Component {
       ...loginOptions,
       storage: postMessageStorage(window.opener, appOrigin)
     }
-    await SolidAuthClient.login(idp.url, loginOptions)
+    await auth.login(idp.url, loginOptions)
   }
 
   componentDidUpdate() {

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,15 @@ Object.getOwnPropertyNames(SolidAuthClient.prototype).forEach(property => {
     auth[property] = value.bind(auth)
   }
 })
+
+// Backward compatibility: expose window.SolidAuthClient
+if (typeof window !== 'undefined') {
+  Object.defineProperty(window, 'SolidAuthClient', {
+    enumerable: true,
+    get: () => {
+      console.warn('window.SolidAuthClient has been deprecated.')
+      console.warn('Please use window.solid.auth instead.')
+      return auth
+    }
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import SolidAuthClient from './solid-auth-client'
 
 // Export a singleton instance of SolidAuthClient
-const instance = new SolidAuthClient()
-export default instance
+const auth = new SolidAuthClient()
+export default auth
 
 // Bind methods to instance, so they can be invoked as regular functions
 // (e.g., to pass around the fetch function)
 Object.getOwnPropertyNames(SolidAuthClient.prototype).forEach(property => {
-  const value = instance[property]
+  const value = auth[property]
   if (typeof value === 'function') {
-    instance[property] = value.bind(instance)
+    auth[property] = value.bind(auth)
   }
 })

--- a/webpack/webpack.lib.config.js
+++ b/webpack/webpack.lib.config.js
@@ -19,7 +19,7 @@ module.exports = {
   output: {
     filename: '[name].bundle.js',
     path: path.resolve(outputDir),
-    library: 'SolidAuthClient',
+    library: ['solid', 'auth'],
     libraryExport: 'default',
     libraryTarget: 'umd'
   },


### PR DESCRIPTION
This pull request exposes the auth client as `solid.auth` in the browser instead of `SolidAuthClient`. This is done for two reasons:

- From a developer experience standpoint, it is nice to have all Solid-related basic building blocks into a single `solid` namespace within the browser.
- Since d149a028e05209c06d7cc2c48b2650a68db633e8, the exported object is an _instance_ of the `SolidAuthClient` class, and the JavaScript convention is to have instances start with a lowercase letter. (Previously, `SolidAuthClient` was a plain object that exposed functions, but it was changed into an instance such that it could become an `EventEmitter` for #56.)

This is a breaking change for client code, so will be released as v3.0.0.