### PR TITLE
Implicit flow auth response - access_token need not be first fragment parameter

### DIFF
--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -34,7 +34,7 @@ export async function currentSession(
       return null
     }
     const url = currentUrl()
-    if (!url || !url.includes('#access_token=')) {
+    if (!url || !(url.includes('#access_token=') || url.includes('&access_token='))) {
       return null
     }
     const storeData = await getData(storage)


### PR DESCRIPTION
<https://openid.net/specs/openid-connect-core-1_0.html#ImplicitAuthResponse> doesn't stipulate a fixed ordering for parameters in the fragment component of the redirection URI returned with a successful implicit flow authentication response. The Virtuoso OIDC provider response doesn't return `access_token` as the first parameter in the fragment.