### PR TITLE
Fix logout not removing session from RP

### DIFF
--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -76,7 +76,7 @@ export default class SolidAuthClient extends EventEmitter {
     const session = await getSession(storage)
     if (session) {
       try {
-        await WebIdOidc.logout(storage)
+        await WebIdOidc.logout(storage, globalFetch)
         this.emit('logout')
         this.emit('session', null)
       } catch (err) {

--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -1,5 +1,5 @@
 // @flow
-/* global RequestInfo, Response, fetch */
+/* global RequestInfo, Response */
 import * as authorization from 'auth-header'
 import RelyingParty from '@solid/oidc-rp'
 import PoPToken from '@solid/oidc-rp/lib/PoPToken'
@@ -55,7 +55,10 @@ export async function currentSession(
   }
 }
 
-export async function logout(storage: AsyncStorage): Promise<void> {
+export async function logout(
+  storage: AsyncStorage,
+  fetch: Function
+): Promise<void> {
   const rp = await getStoredRp(storage)
   if (rp) {
     try {

--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -1,5 +1,5 @@
 // @flow
-/* global RequestInfo, Response */
+/* global RequestInfo, Response, fetch */
 import * as authorization from 'auth-header'
 import RelyingParty from '@solid/oidc-rp'
 import PoPToken from '@solid/oidc-rp/lib/PoPToken'
@@ -59,7 +59,14 @@ export async function logout(storage: AsyncStorage): Promise<void> {
   const rp = await getStoredRp(storage)
   if (rp) {
     try {
-      rp.logout()
+      // First log out from the IDP
+      await rp.logout()
+      // Then, log out from the RP
+      try {
+        await fetch('/.well-known/solid/logout', { credentials: 'include' })
+      } catch (e) {
+        // Ignore errors for when we are not on a Solid pod
+      }
     } catch (err) {
       console.warn('Error logging out of the WebID-OIDC session')
       console.error(err)


### PR DESCRIPTION
The root cause of the problem is that @solid/oidc-rp
logs out from the IDP, but not from the RP.

This fix adds a call to the well-known logout URL from Solid.

Closes solid/oidc-rp#21

Blocked by solid/node-solid-server#927