### PR TITLE
adjusted webpack.popup.config.js for better debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ You can test how `solid-auth-client` operates within an app by running the demo 
 #### Running the demo development server
 
 ```sh
-$ POPUP_URI='http://localhost:8081/popup-template.html' npm run start:demo
+$ POPUP_URI='http://localhost:8606/popup-template.html' npm run start:demo
 ```
 
 #### Running the popup development server

--- a/webpack/webpack.popup.config.js
+++ b/webpack/webpack.popup.config.js
@@ -10,7 +10,8 @@ const {
   context,
   mode,
   module: _module,
-  externals
+  externals,
+  devtool
 } = require('./webpack.common.config')
 
 const outputDir = './dist-popup'
@@ -45,7 +46,9 @@ module.exports = {
     }),
     new HtmlWebpackInlineSourcePlugin()
   ],
+  devtool,
   devServer: {
-    contentBase: path.join(__dirname, 'dist')
+    contentBase: outputDir,
+    port: 8606
   }
 }


### PR DESCRIPTION
running *demo app* with current master didn't allow me to debug the popup, webpack dev server didn't even properly serve `popup-template.html`.

also leaving port in popup dev server undefined, and following *Demo app* section instructions resulted in popup launching on `localhost:8082` and not matching `POPUP_URI` specified in README