### PR TITLE
Implement stopTrackingSession method

### DIFF
--- a/src/__test__/solid-auth-client.spec.js
+++ b/src/__test__/solid-auth-client.spec.js
@@ -411,6 +411,24 @@ describe('trackSession', () => {
   })
 })
 
+describe('stopTrackingSession', () => {
+  it('does not call callback on session change', async () => {
+    expect.assertions(4)
+
+    const callback = jest.fn()
+    await instance.trackSession(callback)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith(null)
+
+    instance.stopTrackingSession(callback)
+
+    const session = {}
+    instance.emit('session', session)
+    expect(callback).toHaveBeenCalledTimes(1)
+    expect(callback).toHaveBeenLastCalledWith(null)
+  })
+})
+
 describe('logout', () => {
   describe('WebID-OIDC', () => {
     let expectedIdToken, expectedAccessToken

--- a/src/__test__/solid-auth-client.spec.js
+++ b/src/__test__/solid-auth-client.spec.js
@@ -411,7 +411,7 @@ describe('trackSession', () => {
   })
 })
 
-describe('stopTrackingSession', () => {
+describe('stopTrackSession', () => {
   it('does not call callback on session change', async () => {
     expect.assertions(4)
 
@@ -420,7 +420,7 @@ describe('stopTrackingSession', () => {
     expect(callback).toHaveBeenCalledTimes(1)
     expect(callback).toHaveBeenLastCalledWith(null)
 
-    instance.stopTrackingSession(callback)
+    instance.stopTrackSession(callback)
 
     const session = {}
     instance.emit('session', session)

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -87,7 +87,7 @@ export default class SolidAuthClient extends EventEmitter {
   }
 
   stopTrackingSession(callback: Function): void {
-    this.off('session', callback)
+    this.removeListener('session', callback)
   }
 
   async logout(storage: AsyncStorage = defaultStorage()): Promise<void> {

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -86,6 +86,10 @@ export default class SolidAuthClient extends EventEmitter {
     this.on('session', callback)
   }
 
+  stopTrackingSession(callback: Function): void {
+    this.off('session', callback)
+  }
+
   async logout(storage: AsyncStorage = defaultStorage()): Promise<void> {
     const session = await getSession(storage)
     if (session) {

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -86,7 +86,7 @@ export default class SolidAuthClient extends EventEmitter {
     this.on('session', callback)
   }
 
-  stopTrackingSession(callback: Function): void {
+  stopTrackSession(callback: Function): void {
     this.removeListener('session', callback)
   }
 


### PR DESCRIPTION
In some situations, it may be desirable to stop tracking session status. This PR implements such a feature.

However, it's important to note that the Flow linter is currently throwing an error, but I'm not sure why. The error in particular is `Cannot call this.off because property off is missing in SolidAuthClient`. I'm not familiar with Flow, but I don't understand why is this failing. The off method exists in the parent class EventEmitter, so it should be ok. The test I implemented is also passing, so the implementation should be correct.