### PR TITLE
Add support for app:// URIs 

### DIFF
--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -28,7 +28,7 @@ export default class SolidAuthClient extends EventEmitter {
    fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
      this.emit('request', toUrlString(input))
      if( toUrlString(input).match(/^app/) ){
-       if(typeof solid.rest==="undefined") {
+       if(typeof solid==="undefined" || typeof solid.rest==="undefined") {
          throw "To use the app:// space, you must first import solid-rest."
        }
        return solid.rest.fetch( input, options )

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -25,10 +25,16 @@ export type loginOptions = {
 export default class SolidAuthClient extends EventEmitter {
   _pendingSession: ?Promise<?Session>
 
-  fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
-    this.emit('request', toUrlString(input))
-    return authnFetch(defaultStorage(), globalFetch, input, options)
-  }
+   fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
+     this.emit('request', toUrlString(input))
+     if( input.match(/^app/) ){
+       if(typeof solid.rest==="undefined") {
+         throw "To use the app:// space, you must first import solid-rest."
+       }
+       return solid.rest.fetch( input, options )
+     }
+     return authnFetch(defaultStorage(), globalFetch, input, options)
+   }
 
   login(idp: string, options: loginOptions): Promise<?Session> {
     options = { ...defaultLoginOptions(currentUrlNoParams()), ...options }

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -36,7 +36,9 @@ export default class SolidAuthClient extends EventEmitter {
           'To use the app:// space, you must first import solid-rest.'
         )
       }
-      return window.solid.rest.fetch(input, options)
+      else {
+          return window.solid.rest.fetch(input, options)
+      }
     }
   }
 

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -27,7 +27,7 @@ export default class SolidAuthClient extends EventEmitter {
 
    fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
      this.emit('request', toUrlString(input))
-     if( input.match(/^app/) ){
+     if( toUrlString(input).match(/^app/) ){
        if(typeof solid.rest==="undefined") {
          throw "To use the app:// space, you must first import solid-rest."
        }

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -27,19 +27,15 @@ export default class SolidAuthClient extends EventEmitter {
 
   fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
     this.emit('request', toUrlString(input))
-      if (toUrlString(input).match(/^app/)) {
-        if (
-          typeof window.solid === 'undefined' ||
-	        typeof window.solid.rest === 'undefined'
-        ) {
-        throw new Error(
-          'To use the app:// space, you must first import solid-rest.'
-        )
-      }
-      else {
-          return window.solid.rest.fetch(input, options)
+    if (toUrlString(input).match(/^app/)) {
+      if (
+        typeof window.solid !== 'undefined' &&
+        typeof window.solid.rest !== 'undefined'
+      ) {
+        return window.solid.rest.fetch(input, options)
       }
     }
+    return authnFetch(defaultStorage(), globalFetch, input, options)
   }
 
   login(idp: string, options: loginOptions): Promise<?Session> {

--- a/src/solid-auth-client.js
+++ b/src/solid-auth-client.js
@@ -25,16 +25,20 @@ export type loginOptions = {
 export default class SolidAuthClient extends EventEmitter {
   _pendingSession: ?Promise<?Session>
 
-   fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
-     this.emit('request', toUrlString(input))
-     if( toUrlString(input).match(/^app/) ){
-       if(typeof solid==="undefined" || typeof solid.rest==="undefined") {
-         throw "To use the app:// space, you must first import solid-rest."
-       }
-       return solid.rest.fetch( input, options )
-     }
-     return authnFetch(defaultStorage(), globalFetch, input, options)
-   }
+  fetch(input: RequestInfo, options?: RequestOptions): Promise<Response> {
+    this.emit('request', toUrlString(input))
+      if (toUrlString(input).match(/^app/)) {
+        if (
+          typeof window.solid === 'undefined' ||
+	        typeof window.solid.rest === 'undefined'
+        ) {
+        throw new Error(
+          'To use the app:// space, you must first import solid-rest.'
+        )
+      }
+      return window.solid.rest.fetch(input, options)
+    }
+  }
 
   login(idp: string, options: loginOptions): Promise<?Session> {
     options = { ...defaultLoginOptions(currentUrlNoParams()), ...options }


### PR DESCRIPTION
This hands-off requests in the app:// space to solid-rest which will handle them via browserFS.  No imports or dependencies needed, user brings their own solid-rest.