### PR TITLE
Update @solid/oidc-rp version to 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,57 +1210,74 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@solid/jose": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@solid/jose/-/jose-0.1.8.tgz",
-      "integrity": "sha512-JuP3z2Yuyolv7P0w7MPhjWltWbVzV0vHBFw+ZhxG2v2WOPdbGT+CvUMhCMdMG/csavceV+IpwMXMybMd8nC4sA==",
+    "@peculiar/asn1-schema": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.0.3.tgz",
+      "integrity": "sha512-Tfgj9eNJ6cTKEtEuidKenLHMx/Q5M8KEE9hnohHqvdpqHJXWYr5RlT3GjAHPjGXy5+mr7sSfuXfzE6aAkEGN7A==",
       "requires": {
-        "@trust/json-document": "^0.1.4",
-        "@trust/webcrypto": "^0.9.2",
-        "base64url": "^3.0.0",
-        "text-encoding": "^0.6.4"
+        "asn1js": "^2.0.22",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.9.tgz",
+      "integrity": "sha512-F2ST2y/IQPgY+1QMw1Q33sqJbGDCeO3lGqI69SL3Hgo0++7iHqprUB1QyxB/A7bN3tuM65MBxoM2JLbwh42lsQ==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.22.tgz",
+      "integrity": "sha512-NP6H6ZGXUvJnQJCWzUgnRcQv+9nMCNwLUDhTwOxRUwPFvtHauMOl0oPTKUjbhInCMaE55gJqB4yc0YKbde6Exw==",
+      "requires": {
+        "@peculiar/asn1-schema": "^1.0.3",
+        "@peculiar/json-schema": "^1.1.6",
+        "asn1js": "^2.0.26",
+        "pvtsutils": "^1.0.9",
+        "tslib": "^1.10.0",
+        "webcrypto-core": "^1.0.17"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
+    "@solid/jose": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@solid/jose/-/jose-0.5.0.tgz",
+      "integrity": "sha512-0Xy5dQvjRSA/mjp4ielwRz18eimqU/C+WDi3Zzj3WfdyRxTs1DeWLH/yPS1ecHgN8TAyw4gg6OM27Y0F8ygyxQ==",
+      "requires": {
+        "@sinonjs/text-encoding": "^0.7.1",
+        "base64url": "^3.0.1",
+        "isomorphic-webcrypto": "^2.3.2"
       }
     },
     "@solid/oidc-rp": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@solid/oidc-rp/-/oidc-rp-0.8.0.tgz",
-      "integrity": "sha512-AAHd+J1IiASDmqDQkU8ou8Gxmc7+VfpcgGFW1rCul/obCsNzSemwvEslxjstK7Yy725HtucoAbZN2BGKujeQAg==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@solid/oidc-rp/-/oidc-rp-0.10.0.tgz",
+      "integrity": "sha512-A5LtjKm4s52JJ9BXYOYvWUCDctUegamzQT1Vynd8tr5VIic0CFnQE/GRGF9sVDoOz192RPva2E4Udr8gGGf9lg==",
       "requires": {
-        "@solid/jose": "0.1.8",
-        "@trust/json-document": "^0.1.4",
-        "@trust/webcrypto": "0.9.2",
-        "base64url": "^3.0.0",
-        "node-fetch": "^2.1.2",
-        "standard-http-error": "^2.0.1",
-        "text-encoding": "^0.6.4",
-        "whatwg-url": "^6.4.1"
-      }
-    },
-    "@trust/json-document": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/@trust/json-document/-/json-document-0.1.4.tgz",
-      "integrity": "sha1-sgI7HhRbp2hb0fNux7aRKJQAc+k="
-    },
-    "@trust/keyto": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@trust/keyto/-/keyto-0.3.7.tgz",
-      "integrity": "sha512-t5kWWCTkPgg24JWVuCTPMx7l13F7YHdxBeJkT1vmoHjROgiOIEAN8eeY+iRmP1Hwsx+S7U55HyuqSsECr08a8A==",
-      "requires": {
-        "asn1.js": "^5.0.1",
+        "@solid/jose": "^0.5.0",
         "base64url": "^3.0.1",
-        "elliptic": "^6.4.1"
-      }
-    },
-    "@trust/webcrypto": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/@trust/webcrypto/-/webcrypto-0.9.2.tgz",
-      "integrity": "sha512-5iMAVcGYKhqLJGjefB1nzuQSqUJTru0nG4CytpBT/GGp1Piz/MVnj2jORdYf4JBYzggCIa8WZUr2rchP2Ngn/w==",
-      "requires": {
-        "@trust/keyto": "^0.3.4",
-        "base64url": "^3.0.0",
-        "elliptic": "^6.4.0",
-        "node-rsa": "^0.4.0",
-        "text-encoding": "^0.6.1"
+        "isomorphic-webcrypto": "^2.3.2",
+        "node-fetch": "^2.6.0",
+        "standard-http-error": "^2.0.1",
+        "whatwg-url": "^7.1.0"
+      },
+      "dependencies": {
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
       }
     },
     "@types/babel__core": {
@@ -1378,6 +1395,26 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
       "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "dev": true
+    },
+    "@unimodules/core": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@unimodules/core/-/core-5.0.0.tgz",
+      "integrity": "sha512-PswccfzFIviX61Lm8h6/QyC94bWe+6cARwhzgzTCKa6aR6azmi4732ExhX4VxfQjJNHB0szYVXGXVEDsFkj+tQ==",
+      "optional": true,
+      "requires": {
+        "compare-versions": "^3.4.0"
+      }
+    },
+    "@unimodules/react-native-adapter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@unimodules/react-native-adapter/-/react-native-adapter-5.0.0.tgz",
+      "integrity": "sha512-qb5p5wUQoi3TRa/33aLLHSnS7sewV99oBxIo9gnzNI3VFzbOm3rsbTjOJNcR2hx0raUolTtnQT75VbgagVQx4w==",
+      "optional": true,
+      "requires": {
+        "invariant": "^2.2.4",
+        "lodash": "^4.5.0",
+        "prop-types": "^15.6.1"
+      }
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -1768,19 +1805,23 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asmcrypto.js": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-0.22.0.tgz",
+      "integrity": "sha512-usgMoyXjMbx/ZPdzTSXExhMPur2FTdz/Vo5PVx2gIaBcdAAJNOFlsdgqveM8Cff7W0v+xrf9BwjOV26JSAF9qA=="
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
-    "asn1.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.2.0.tgz",
-      "integrity": "sha512-Q7hnYGGNYbcmGrCPulXfkEw7oW7qjWeM4ZTALmgpuIcZLxyqqKYWxCZg2UBm8bklrnB4m2mGyJPWfoktdORD8A==",
+    "asn1js": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
       "requires": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
+        "pvutils": "^1.0.17"
       }
     },
     "assert": {
@@ -1880,6 +1921,22 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
+    },
+    "b64-lite": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/b64-lite/-/b64-lite-1.4.0.tgz",
+      "integrity": "sha512-aHe97M7DXt+dkpa8fHlCcm1CnskAHrJqEfMI0KN7dwqlzml/aUe1AGt6lk51HzrSfVD67xOso84sOpr+0wIe2w==",
+      "requires": {
+        "base-64": "^0.1.0"
+      }
+    },
+    "b64u-lite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/b64u-lite/-/b64u-lite-1.1.0.tgz",
+      "integrity": "sha512-929qWGDVCRph7gQVTC6koHqQIpF4vtVaSbwLltFQo44B1bYUquALswZdBKFfrJCPEnsCOvWkJsPdQYZ/Ukhw8A==",
+      "requires": {
+        "b64-lite": "^1.4.0"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -2085,11 +2142,15 @@
         }
       }
     },
+    "base-64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
+      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+    },
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "base64url": {
       "version": "3.0.1",
@@ -2132,7 +2193,8 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.19.0",
@@ -2228,7 +2290,8 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
@@ -2779,6 +2842,12 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.5.1.tgz",
+      "integrity": "sha512-9fGPIB7C6AyM18CJJBHt5EnCZDG3oiTJYy0NjfIAGjKpzv0tkxWko7TNQHF5ymqm7IH03tqmeuBxtvD+Izh6mg==",
+      "optional": true
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -3503,6 +3572,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.0.tgz",
       "integrity": "sha512-eFOJTMyCYb7xtE/caJ6JJu+bhi67WCYNbkGSknu20pmM8Ke/bqOfdnZWxyoGN26JgfxTbXrsCkEw4KheCT/KGg==",
+      "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
         "brorand": "^1.0.1",
@@ -4135,6 +4205,15 @@
         "jest-matcher-utils": "^24.9.0",
         "jest-message-util": "^24.9.0",
         "jest-regex-util": "^24.9.0"
+      }
+    },
+    "expo-random": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/expo-random/-/expo-random-8.0.0.tgz",
+      "integrity": "sha512-ukDC3eGSEliBsnobX1bQRAwti9GE8ZEW53AHFf1fVy+JuAhhZm+M5HW7T0ptdbLjm46VpTDGIO4vq+qxeXAl7g==",
+      "optional": true,
+      "requires": {
+        "base64-js": "^1.3.0"
       }
     },
     "express": {
@@ -5417,6 +5496,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -5432,6 +5512,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -5770,7 +5851,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -5836,7 +5918,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -6153,6 +6234,24 @@
             "is-stream": "^1.0.1"
           }
         }
+      }
+    },
+    "isomorphic-webcrypto": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/isomorphic-webcrypto/-/isomorphic-webcrypto-2.3.4.tgz",
+      "integrity": "sha512-SnOCsm0Vls8jeWP4c26ItHFajzfDlRPcKK4YRUv6jukYGzJwl2tKNwSIAiCh1INdoRttaKhJrLc3HBer1om4HA==",
+      "requires": {
+        "@peculiar/webcrypto": "^1.0.22",
+        "@unimodules/core": "*",
+        "@unimodules/react-native-adapter": "*",
+        "asmcrypto.js": "^0.22.0",
+        "b64-lite": "^1.3.1",
+        "b64u-lite": "^1.0.1",
+        "expo-random": "*",
+        "msrcrypto": "^1.5.6",
+        "react-native-securerandom": "^0.1.1",
+        "str2buf": "^1.3.0",
+        "webcrypto-shim": "^0.1.4"
       }
     },
     "isstream": {
@@ -6716,8 +6815,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -7021,8 +7119,7 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-      "dev": true
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.includes": {
       "version": "4.3.0",
@@ -7130,7 +7227,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -7317,12 +7413,14 @@
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "dev": true
     },
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -7406,6 +7504,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "msrcrypto": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/msrcrypto/-/msrcrypto-1.5.8.tgz",
+      "integrity": "sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q=="
     },
     "multicast-dns": {
       "version": "6.2.3",
@@ -7614,14 +7717,6 @@
         "semver": "^5.3.0"
       }
     },
-    "node-rsa": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
-      "integrity": "sha1-1jkXKewWqDDtWjgEKzFX0tXXJTA=",
-      "requires": {
-        "asn1": "0.2.3"
-      }
-    },
     "normalize-package-data": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
@@ -7679,8 +7774,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -8860,7 +8954,6 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -8953,6 +9046,19 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
+    "pvtsutils": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.9.tgz",
+      "integrity": "sha512-/kDsuCKPqJuIzn37w6+iN+TiSrN+zrwPEd7FjT61oNbRvceGdsS94fMEWZ4/h6QZU5EZhBMiV+79IYedroP/Yw==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
+    },
+    "pvutils": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -9025,8 +9131,16 @@
     "react-is": {
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-      "dev": true
+      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+    },
+    "react-native-securerandom": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-securerandom/-/react-native-securerandom-0.1.1.tgz",
+      "integrity": "sha1-8TBiOkEsM4sK+t7bwgTFy7i/IHA=",
+      "optional": true,
+      "requires": {
+        "base64-js": "*"
+      }
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -10269,6 +10383,11 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
+    "str2buf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/str2buf/-/str2buf-1.3.0.tgz",
+      "integrity": "sha512-xIBmHIUHYZDP4HyoXGHYNVmxlXLXDrtFHYT0eV6IOdEj3VO9ccaF1Ejl9Oq8iFjITllpT8FhaXb4KsNmw+3EuA=="
+    },
     "stream-browserify": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -10604,11 +10723,6 @@
         }
       }
     },
-    "text-encoding": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -10760,8 +10874,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -11226,6 +11339,20 @@
         "minimalistic-assert": "^1.0.0"
       }
     },
+    "webcrypto-core": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.17.tgz",
+      "integrity": "sha512-7jxTLgtM+TahBPErx/Dd2XvxFDfWJrHxjVeTSvIa4LSgiYrmCPlC2INiAMAfb8MbtHiwJKKqF5sPS0AWNjBbXw==",
+      "requires": {
+        "pvtsutils": "^1.0.9",
+        "tslib": "^1.10.0"
+      }
+    },
+    "webcrypto-shim": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/webcrypto-shim/-/webcrypto-shim-0.1.5.tgz",
+      "integrity": "sha512-mE+E00gulvbLjHaAwl0kph60oOLQRsKyivEFgV9DMM/3Y05F1vZvGq12hAcNzHRnYxyEOABBT/XMtwGSg5xA7A=="
+    },
     "webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -11667,6 +11794,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "@solid/oidc-rp": "^0.8.0",
+    "@solid/oidc-rp": "^0.10.0",
     "auth-header": "^1.0.0",
     "commander": "^2.11.0",
     "isomorphic-fetch": "^2.2.1"

--- a/src/webid-oidc.js
+++ b/src/webid-oidc.js
@@ -2,7 +2,7 @@
 /* global Response */
 import * as authorization from 'auth-header'
 import RelyingParty from '@solid/oidc-rp'
-import PoPToken from '@solid/oidc-rp/lib/PoPToken'
+import PoPToken from '@solid/oidc-rp/src/PoPToken'
 
 import type { loginOptions } from './solid-auth-client'
 import { currentUrl, navigateTo, toUrlString } from './url-util'
@@ -153,11 +153,14 @@ function registerRp(idp: string, opts: loginOptions): Promise<RelyingParty> {
     ...supplementaryOptions
   }
 
+  // Note that overrides @solid/oidc-rp/RelyingParty defaults (i.e. not merged)
   const options = {
     defaults: {
       authenticate: {
         redirect_uri: callbackUri,
-        response_type: responseType
+        response_type: responseType,
+        display: 'page',
+        scope: ['openid']
       }
     },
     store: storage


### PR DESCRIPTION
@solid/oidc-rp was updated to 0.10.0, this version removes the dependencies with @trust/json-document and @trust/webcrypto. A good thing because the JSON schema validator causes some problems with Content Security Policies. :smile_cat: